### PR TITLE
[fix] 이름-뱃지 스택 중앙 정렬

### DIFF
--- a/Sinzak/Scene/MyProfile/Profile/View/MyProfileView.swift
+++ b/Sinzak/Scene/MyProfile/Profile/View/MyProfileView.swift
@@ -344,7 +344,7 @@ final class MyProfileView: SZView {
             make.top.equalToSuperview().inset(23)
         }
         nameBadgeStack.snp.makeConstraints { make in
-            make.centerX.equalToSuperview().offset(0)
+            make.centerX.equalToSuperview()
             make.top.equalTo(profileImage.snp.bottom).offset(12)
         }
         badgeImage.snp.makeConstraints { make in

--- a/Sinzak/Scene/MyProfile/Profile/View/MyProfileView.swift
+++ b/Sinzak/Scene/MyProfile/Profile/View/MyProfileView.swift
@@ -344,7 +344,7 @@ final class MyProfileView: SZView {
             make.top.equalToSuperview().inset(23)
         }
         nameBadgeStack.snp.makeConstraints { make in
-            make.centerX.equalToSuperview().offset(6)
+            make.centerX.equalToSuperview().offset(0)
             make.top.equalTo(profileImage.snp.bottom).offset(12)
         }
         badgeImage.snp.makeConstraints { make in


### PR DESCRIPTION
### 작업내용
- 프로필 화면에서 이름이 중앙 정렬되어 있지 않은 이슈를 해결하였습니다.

### 이슈 넘버
#115 