### PR TITLE
[Fix] 글쓰기 사진 업로드시 1mb 초과시 파일 크기 압축

### DIFF
--- a/Sinzak.xcodeproj/project.pbxproj
+++ b/Sinzak.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		EDC5147129DBB48F0015C3B5 /* LoginVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC5147029DBB48F0015C3B5 /* LoginVM.swift */; };
 		EDC8656229D5BADD00424FC1 /* MarketVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC8656129D5BADD00424FC1 /* MarketVM.swift */; };
 		EDCA46F72A156A5D00EAFEAA /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCA46F62A156A5D00EAFEAA /* Photo.swift */; };
+		EDD363342A49571E008C42C7 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD363332A49571E008C42C7 /* UIImage+Extension.swift */; };
 		EDD446DE29DF14F5005DD268 /* sinzak_splash_animation_dark.json in Resources */ = {isa = PBXBuildFile; fileRef = EDD446DD29DF14F5005DD268 /* sinzak_splash_animation_dark.json */; };
 		EDE25CA72A25139F00B216DB /* UICollectionReusableView+Extentsion.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE25CA62A25139E00B216DB /* UICollectionReusableView+Extentsion.swift */; };
 		EDE25CA92A25149F00B216DB /* NSNotification-Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE25CA82A25149F00B216DB /* NSNotification-Name+Extension.swift */; };
@@ -532,6 +533,7 @@
 		EDC5147029DBB48F0015C3B5 /* LoginVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVM.swift; sourceTree = "<group>"; };
 		EDC8656129D5BADD00424FC1 /* MarketVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketVM.swift; sourceTree = "<group>"; };
 		EDCA46F62A156A5D00EAFEAA /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
+		EDD363332A49571E008C42C7 /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		EDD446DD29DF14F5005DD268 /* sinzak_splash_animation_dark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = sinzak_splash_animation_dark.json; sourceTree = "<group>"; };
 		EDE25CA62A25139E00B216DB /* UICollectionReusableView+Extentsion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionReusableView+Extentsion.swift"; sourceTree = "<group>"; };
 		EDE25CA82A25149F00B216DB /* NSNotification-Name+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSNotification-Name+Extension.swift"; sourceTree = "<group>"; };
@@ -668,6 +670,7 @@
 				EDE5EC5C29D6FBAA00BB211F /* UICollectionReusableView+Extentsion.swift */,
 				ED86969129D9359D001A1A9F /* UIView+Extension.swift */,
 				ED19B13F29EC6DE100C951D1 /* UIScrollView+Extension.swift */,
+				EDD363332A49571E008C42C7 /* UIImage+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2733,6 +2736,7 @@
 				ED3552602A11F0A800B364FC /* VerifyButton.swift in Sources */,
 				A226CC5229AE0FC8000161E8 /* ReceivePriceOfferView.swift in Sources */,
 				A280AB5329A7A5E600C1729C /* WriteCategoryHeaderKind.swift in Sources */,
+				EDD363342A49571E008C42C7 /* UIImage+Extension.swift in Sources */,
 				EDF76FF129F7BD3E00F33146 /* ProductsDetail.swift in Sources */,
 				A2DEC35B29B44E2E00CF0794 /* SNSLogin.swift in Sources */,
 				ED47113429DF2EE400708562 /* AgreementVM.swift in Sources */,

--- a/Sinzak/Data/Network/API/ProductsAPI.swift
+++ b/Sinzak/Data/Network/API/ProductsAPI.swift
@@ -136,7 +136,7 @@ extension ProductsAPI: TargetType {
         case .imageUpload(_, let images):
             var formData: [MultipartFormData] = []
             for image in images {
-                if let imageData = image.jpegData(compressionQuality: 0.3) {
+                if let imageData = image.compressImageData() {
                     let name = String.uniqueFilename(withPrefix: "IMAGE")
                     formData.append(MultipartFormData(
                         provider: .data(imageData),

--- a/Sinzak/Global/Extension/UIImage+Extension.swift
+++ b/Sinzak/Global/Extension/UIImage+Extension.swift
@@ -1,0 +1,66 @@
+//
+//  UIImage+Extension.swift
+//  Sinzak
+//
+//  Created by JongHoon on 2023/06/26.
+//
+
+import UIKit
+
+extension UIImage {
+    
+    func compressImageData(targetMB: Double = 1.0) -> Data? {
+        guard var imageSize = self.jpegData(compressionQuality: 0.8)?.count else { return nil }
+        let resizeLength = 2048
+        var compressedImage: UIImage? = self
+        var resizeScale = 1.0
+        while Double(imageSize) > targetMB * pow(2, 20) {
+            compressedImage = self.resized(toLength: Double(resizeLength) * resizeScale)
+            imageSize = compressedImage?.jpegData(compressionQuality: 0.8)?.count ?? 0
+            resizeScale *= 0.75
+        }
+
+        return compressedImage?.jpegData(compressionQuality: 0.8)
+    }
+    
+    func resized(toLength length: CGFloat) -> UIImage? {
+        let canvasSize = size.width > size.height
+        ? CGSize(
+            width: length,
+            height: CGFloat(ceil(length/size.width * size.height))
+        )
+        : CGSize(
+            width: CGFloat(ceil(length/size.height * size.width)),
+            height: length
+        )
+        
+        UIGraphicsBeginImageContextWithOptions(canvasSize, false, scale)
+        defer { UIGraphicsEndImageContext() }
+        draw(in: CGRect(origin: .zero, size: canvasSize))
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
+    
+    func resized(scale: CGFloat) -> UIImage? {
+        let canvasSize = CGSize(
+            width: round(self.size.width * scale),
+            height: round(self.size.height * scale)
+        )
+        UIGraphicsBeginImageContextWithOptions(canvasSize, false, scale)
+        defer { UIGraphicsEndImageContext() }
+        draw(in: CGRect(origin: .zero, size: canvasSize))
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
+
+    func resize(scale: CGFloat) -> UIImage {
+        let newWidth = round(self.size.width * scale)
+        let newHeight = round(self.size.height * scale)
+        
+        let size = CGSize(width: newWidth, height: newHeight)
+        let render = UIGraphicsImageRenderer(size: size)
+        let renderImage = render.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: size))
+        }
+        
+        return renderImage
+    }
+}

--- a/Sinzak/Scene/Write/WritePost/VM/WritePostVM.swift
+++ b/Sinzak/Scene/Write/WritePost/VM/WritePostVM.swift
@@ -97,7 +97,8 @@ final class DefaultAddPhotosVM: WritePostVM {
             price: price
         )
         
-        let images: [UIImage] = photoSections.value[0].items
+        var images: [UIImage] = photoSections.value[0].items
+        images.removeFirst()
         
         ProductsManager.shared.buildProductsPost(
             products: marketBuild,
@@ -129,7 +130,9 @@ final class DefaultAddPhotosVM: WritePostVM {
             suggest: suggest
         )
         
-        let images: [UIImage] = photoSections.value[0].items
+        var images: [UIImage] = photoSections.value[0].items
+        images.removeFirst()
+        
         WorksManager.shared.buildWorksPost(works: worksBuild, images: images)
             .subscribe(
                 with: self,


### PR DESCRIPTION
## 작업 내용

- 글쓰기 사진 업로드시 1mb 초과시 파일 크기 압축
- 사진 업로드시 사진 추가 cell의 image 반영되지 않게 수정

## 이슈 번호

#112 