### PR TITLE
[Fix] artCVC Height 기종에 맞게 수정

### DIFF
--- a/Sinzak/Scene/Market/View/MarketSkeletonView.swift
+++ b/Sinzak/Scene/Market/View/MarketSkeletonView.swift
@@ -18,7 +18,10 @@ final class MarketSkeletonView: SZView {
         let width = UIScreen.main.bounds.width
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.estimatedItemSize = CGSize(width: (width - 48.0) / 2, height: 264)
+        layout.estimatedItemSize = CGSize(
+            width: (width - 48.0) / 2,
+            height: (width - 48.0) / 2 + 88.0
+        )
         layout.sectionInset = UIEdgeInsets(top: 0.0, left: 16.0, bottom: 0, right: 16.0)
         
         return layout

--- a/Sinzak/Scene/Market/View/MarketSkeletonView.swift
+++ b/Sinzak/Scene/Market/View/MarketSkeletonView.swift
@@ -18,9 +18,12 @@ final class MarketSkeletonView: SZView {
         let width = UIScreen.main.bounds.width
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
+        let insets = 16.0 * 3
+        let heightOfImageView = (width-insets) / 2
+        let heightOfLabels = 88.0
         layout.estimatedItemSize = CGSize(
-            width: (width - 48.0) / 2,
-            height: (width - 48.0) / 2 + 88.0
+            width: (width - insets) / 2,
+            height: heightOfImageView + heightOfLabels
         )
         layout.sectionInset = UIEdgeInsets(top: 0.0, left: 16.0, bottom: 0, right: 16.0)
         

--- a/Sinzak/Scene/Market/View/MarketView.swift
+++ b/Sinzak/Scene/Market/View/MarketView.swift
@@ -159,7 +159,7 @@ extension MarketView {
             )
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(264)
+                heightDimension: .estimated((UIScreen.main.bounds.width-48)/2 + 88.0)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             item.contentInsets.leading = 8

--- a/Sinzak/Scene/Market/View/MarketView.swift
+++ b/Sinzak/Scene/Market/View/MarketView.swift
@@ -157,9 +157,12 @@ extension MarketView {
                 widthDimension: .fractionalWidth(0.5),
                 heightDimension: .fractionalHeight(1.0)
             )
+            let insets = 16.0 * 3
+            let heightOfImageView = (UIScreen.main.bounds.width-insets)/2
+            let heightOfLabels = 88.0
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated((UIScreen.main.bounds.width-48)/2 + 88.0)
+                heightDimension: .estimated(heightOfImageView + heightOfLabels)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             item.contentInsets.leading = 8

--- a/Sinzak/Scene/Works/View/WorksView.swift
+++ b/Sinzak/Scene/Works/View/WorksView.swift
@@ -129,9 +129,12 @@ extension WorksView {
                 widthDimension: .fractionalWidth(0.5),
                 heightDimension: .fractionalHeight(1.0)
             )
+            let insets = 16.0 * 3
+            let heightOfImageView = (UIScreen.main.bounds.width - insets) / 2
+            let heightOfLabels = 88.0
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated((UIScreen.main.bounds.width-48)/2 + 88.0)
+                heightDimension: .estimated(heightOfImageView + heightOfLabels)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             item.contentInsets.leading = 8

--- a/Sinzak/Scene/Works/View/WorksView.swift
+++ b/Sinzak/Scene/Works/View/WorksView.swift
@@ -131,7 +131,7 @@ extension WorksView {
             )
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(264)
+                heightDimension: .estimated((UIScreen.main.bounds.width-48)/2 + 88.0)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             item.contentInsets.leading = 8


### PR DESCRIPTION
## 작업내용
- 마켓, 의뢰 화면에서 artCVC Height 기종에 맞게 수정
- skeleton view의 artCVC Height 기종에 맞게 수정

## 이슈 번호

#113 

## 스크린 샷

- iPhone 8

<img width="399" alt="스크린샷 2023-06-27 오전 1 41 37" src="https://github.com/SINZAK/sinzak-ios/assets/98168685/aa2682c0-e70a-4085-b3f7-0a5f0607d1a0">

- iPhone 14 Plus

<img width="447" alt="스크린샷 2023-06-27 오전 1 40 17" src="https://github.com/SINZAK/sinzak-ios/assets/98168685/3d09b169-b61d-4c73-a189-2b1bef94938a">
