### PR TITLE
[no] 로그인 실패 시 alert가 뜨지 않는 이슈 해결

### DIFF
--- a/Sinzak.xcodeproj/project.pbxproj
+++ b/Sinzak.xcodeproj/project.pbxproj
@@ -3132,7 +3132,7 @@
 			repositoryURL = "https://github.com/onevcat/Kingfisher";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 7.5.0;
+				minimumVersion = 7.6.0;
 			};
 		};
 		A254E15229BE0413001047FD /* XCRemoteSwiftPackageReference "RxKeyboard" */ = {

--- a/Sinzak/Scene/Login/VC/LoginVC.swift
+++ b/Sinzak/Scene/Login/VC/LoginVC.swift
@@ -135,6 +135,7 @@ final class LoginVC: SZVC {
         viewModel.errorHandler
             .observe(on: MainScheduler.instance)
             .bind(with: self, onNext: { owner, error in
+                Log.error(error)
                 if error is APIError {
                     let apiError = error as! APIError
                     
@@ -144,15 +145,15 @@ final class LoginVC: SZVC {
                     case .badStatus(code: _):
                         owner.showSinglePopUpAlert(message: "알 수 없는 오류가 발생했습니다.")
                     default:
-                        Log.error(error)
+                        break
                     }
                 } else {
-                    Log.error(error)
+                    owner.showSinglePopUpAlert(message: "알 수 없는 오류가 발생했습니다.")
                 }
                 
                 self.hideLoading()
                 
-                UserApi.shared.logout {(error) in
+                UserApi.shared.logout { (error) in
                     if let error = error {
                         Log.error(error)
                     } else {


### PR DESCRIPTION
## 작업내용
- 로그인 실패 시 alert가 뜨지 않는 이슈를 해결했습니다.

## 참고
- 500번이 뜨면 APIError를 throw 할텐데 그렇지 않은 이유가 뭘까요.. 일단 분기 탄 곳에 alert 뜨게 했는데 원인을 찾아봐야할 것 같습니다.